### PR TITLE
v0.0.2 version bump and changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.2 - 2023-??-?? - ???
+## v0.0.2 - 2023-09-12 - Verification
 
 * octodns.processor.spf.SpfDnsLookupProcessor ported in to this module as
   octodns_spf.SpfDnsLookupProcessor, deprecated the octoDNS core version.

--- a/octodns_spf/__init__.py
+++ b/octodns_spf/__init__.py
@@ -5,6 +5,8 @@
 from .processor import SpfDnsLookupProcessor
 from .source import SpfSource
 
+__VERSION__ = '0.0.2'
+
 # Quell warnings
 SpfDnsLookupProcessor
 SpfSource

--- a/octodns_spf/source.py
+++ b/octodns_spf/source.py
@@ -10,8 +10,6 @@ from octodns.source.base import BaseSource
 
 from .processor import SpfDnsLookupProcessor
 
-__VERSION__ = '0.0.1'
-
 
 class SpfException(RecordException):
     def __init__(self, msg, record=None):


### PR DESCRIPTION
## v0.0.2 - 2023-09-12 - Verification

* octodns.processor.spf.SpfDnsLookupProcessor ported in to this module as
  octodns_spf.SpfDnsLookupProcessor, deprecated the octoDNS core version.
* Add verify_dns_lookups option to SpfSource

