### PR TITLE
Add LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,25 @@
+MIT License
+
+Copyright (c) 2021 Ross McFarland & the octoDNS Maintainers
+Copyright (c) 2017 GitHub, Inc.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/octodns_spf/processor.py
+++ b/octodns_spf/processor.py
@@ -22,9 +22,9 @@ class SpfDnsLookupException(ProcessorException):
 class SpfDnsLookupProcessor(BaseProcessor):
     log = getLogger('SpfDnsLookupProcessor')
 
-    def __init__(self, name):
-        self.log.debug(f"SpfDnsLookupProcessor: {name}")
-        super().__init__(name)
+    def __init__(self, id):
+        self.log.debug('__init__:')
+        super().__init__(id)
 
     def _get_spf_from_txt_values(
         self, fqdn: str, values: List[str]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -35,6 +35,8 @@ requests-toolbelt==1.0.0
 requests==2.31.0
 rfc3986==2.0.0
 rich==13.6.0
+setuptools==68.2.2
 twine==4.0.2
 urllib3==2.0.6
+wheel==0.41.2
 zipp==3.17.0

--- a/script/cibuild-setup-py
+++ b/script/cibuild-setup-py
@@ -7,6 +7,7 @@ echo "## create test venv ######################################################
 TMP_DIR=$(mktemp -d -t ci-XXXXXXXXXX)
 python3 -m venv $TMP_DIR
 . "$TMP_DIR/bin/activate"
+pip install setuptools
 echo "## environment & versions ######################################################"
 python --version
 pip --version


### PR DESCRIPTION
Based on what octoDNS core has always been/had. It was an oversight not to include a LICENSE when things were split out of core.

/cc octodns/octodns-hetzner#27