### PR TITLE
pytest warnings as errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,7 @@ sections="FUTURE,STDLIB,THIRDPARTY,OCTODNS,FIRSTPARTY,LOCALFOLDER"
 
 [tool.pytest.ini_options]
 log_level = 'DEBUG'
+filterwarnings = [
+    'error',
+]
 pythonpath = "."


### PR DESCRIPTION
Bump python warnings to error during pytest, and fix any existing warnings

/cc octodns/octodns#1108
