### PR TITLE
Version 1.0.0 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.0.0 - 2025-05-04 - Long overdue 1.0
+
+* Removes SPF record support
+* Requires octoDNS >= 2.0.0
+
 ## v0.0.2 - 2023-09-12 - Verification
 
 * octodns.processor.spf.SpfDnsLookupProcessor ported in to this module as

--- a/octodns_spf/__init__.py
+++ b/octodns_spf/__init__.py
@@ -6,7 +6,7 @@ from .processor import SpfDnsLookupProcessor
 from .source import SpfSource
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.2'
+__version__ = __VERSION__ = '1.0.0'
 
 # Quell warnings
 SpfDnsLookupProcessor


### PR DESCRIPTION
# v1.0.0 - 2025-05-04 - Long overdue 1.0

* Removes SPF record support
* Requires octoDNS >= 2.0.0